### PR TITLE
DTSPO-6556 - allow use of ingressClass annotations

### DIFF
--- a/config/samples/ingress.yaml
+++ b/config/samples/ingress.yaml
@@ -1,17 +1,18 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: test-ingress-matt
-  namespace: toffee
+  # Ingress used to test ingresses with ingressClassName in it's spec
+  name: reply-urls-ingressclass-spec
+  namespace: default
 spec:
   ingressClassName: traefik
   rules:
-  - host: test-matt.ssandbox.platform.hmcts.net
+  - host: reply-urls-ingressclass.demo.platform.hmcts.net
     http:
       paths:
       - backend:
           service:
-            name: toffee-frontend-nodejs
+            name: reply-urls-demo
             port:
               number: 80
         path: /

--- a/controllers/ingress_controller.go
+++ b/controllers/ingress_controller.go
@@ -136,14 +136,18 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if replyURLSync.Spec.ClientID != nil {
-		os.Setenv("AZURE_CLIENT_ID", *replyURLSync.Spec.ClientID)
+		if err = os.Setenv("AZURE_CLIENT_ID", *replyURLSync.Spec.ClientID); err != nil {
+			return ctrl.Result{}, err
+		}
 	} else {
 		workerLog.Info("Missing configuration", "ClientID was not found in sync config")
 		return ctrl.Result{}, nil
 	}
 
 	if replyURLSync.Spec.TenantID != nil {
-		os.Setenv("AZURE_TENANT_ID", *replyURLSync.Spec.TenantID)
+		if err = os.Setenv("AZURE_TENANT_ID", *replyURLSync.Spec.TenantID); err != nil {
+			return ctrl.Result{}, err
+		}
 	} else {
 		workerLog.Info("Missing configuration", "TenantID was not found in sync config")
 		return ctrl.Result{}, nil
@@ -226,14 +230,18 @@ func (r *IngressReconciler) cleanReplyURLSyncList() (result ctrl.Result, err err
 		}
 
 		if syncSpec.ClientID != nil {
-			os.Setenv("AZURE_CLIENT_ID", *syncSpec.ClientID)
+			if err = os.Setenv("AZURE_CLIENT_ID", *syncSpec.ClientID); err != nil {
+				return ctrl.Result{}, err
+			}
 		} else {
 			workerLog.Info("Environment Variable Missing", "AZURE_CLIENT_ID")
 			return ctrl.Result{}, nil
 		}
 
 		if syncSpec.TenantID != nil {
-			os.Setenv("AZURE_TENANT_ID", *syncSpec.TenantID)
+			if err = os.Setenv("AZURE_TENANT_ID", *syncSpec.TenantID); err != nil {
+				return ctrl.Result{}, err
+			}
 		} else {
 			workerLog.Info("Environment Variable Missing", "AZURE_TENANT_ID")
 			return ctrl.Result{}, nil


### PR DESCRIPTION
### Change description ###
The operator will now also pick up any ingresses using annotations instead of the ingressClassName in its spec


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
